### PR TITLE
docs: project instructions refresh (AUTO discovery & Upload-Exactly)

### DIFF
--- a/docs/PROJECT_INSTRUCTIONS.md
+++ b/docs/PROJECT_INSTRUCTIONS.md
@@ -1,20 +1,131 @@
-# Q‑Chain Two‑Model — Project Instructions (context‑agnostic)
+# Q‑Chain Two‑Model — Project Instructions (content‑agnostic)
 
-## Triggers & cues (exact words)
-- AUTO:BUILD‑FRAMEWORK → Intake + Question Chain Draft (atomic unknown IDs + blocks|informs edges), Now/Next/Later, two process‑only Handoff Manifests, Repo‑Change Inventory (RCI), Idempotent Change Preview (chain artifacts only: node YAML unknowns + QUESTION_GRAPH). **No PRs.**
-- REVISE RCI: <notes> → Revise the plan.
-- APPLY RCI → Open add‑only PR(s) and write a Handoff Pack under `artefacts/handoff/<pack_id>/`.
-- APPLY PRO <pack_id> → Apply PRO’s diffs/issues/agenda/notes; update graph if IDs changed.
-- MERGE #<pr> / RECORD PROGRESS #<pr> → Close the turn.
+**Source of truth:** atillaorgunmat/qchain-starter@main. If this header and the repo differ, the **repo wins**.
 
-## Mapping heuristic (context‑agnostic)
-Route unknowns by function: POL rules/authority; REV offers; BD prospects/pitches; PLAT channels; WF steps/roles; RSCH validation; AN metrics; OPS automation.
+---
 
-## Cross‑node invariants (context‑agnostic)
-POL → blocks → BD; REV → blocks → BD; PLAT → informs → WF; RSCH → informs → REV; WF → informs → BD; AN → informs → REV|WF.
+## Roles (strict split)
 
-## Upload discipline (PRO)
-PRO consumes only files listed in `upload_exactly`. If PRO used extra context, it must WARN “framework relation missing; please update” and suggest exactly what to add to nodes/graph.
+- **AUTO (Ops/IO)**  
+  Reads repo state, asks clarifying questions, packages **Upload‑Exactly ZIPs** (pinned to a commit), regenerates the derived graph, validates, opens PRs, merges.
 
-## IDs & provenance
-Unknown IDs: UNK‑<NODE>‑NN (zero‑padded). Write a one‑line provenance note (source + date) into each affected node’s `notes[]`.
+- **PRO (Reason/Authoring)**  
+  Consumes only the **attached ZIP**; updates/creates **question YAMLs** and lightweight docs; returns an **add‑only Handoff Pack** with an **Idempotent Change Preview** and **issue one‑liners**. PRO never pushes directly to the repo.
+
+---
+
+## Cues / exact trigger words
+
+- `AUTO:BUILD-FRAMEWORK` — (optional) initial scaffold.
+- `STATUS SYNC` — brief state report.
+- `DISCOVER & PREP PRO PACK — AUTO-LED` — **standard entry point** per cycle.
+- `SHOW CHAIN — READABLE VIEW` — tabular/topological view of questions and gaps.
+- `REVISE RCI: <notes>` — change the plan pre‑apply.
+- `APPLY RCI` — apply AUTO’s repo‑change inventory (add‑only).
+- `APPLY PRO <pack_id>` — apply a PRO handoff pack (add‑only).
+- `MERGE #<pr>` / `RECORD PROGRESS #<pr>` — close a turn.
+
+---
+
+## Operating cycle (one loop)
+
+1) **AUTO discovery pass (pinned to HEAD)**  
+   AUTO inventories the repo: nodes, questions, derived graph, gaps. It asks ≤5 clarifying questions, then proposes **2–3 pack options** and recommends **one**.
+
+2) **AUTO produces Upload‑Exactly**  
+   A **commit‑pinned ZIP** named `upload_exactly_<pack_id>_<SHA>.zip` + `MANIFEST.lock` (sha256, size, path) + `pack_id.txt` (commit SHA). Only the listed files. No extras.
+
+3) **PRO authoring**  
+   New PRO chat. You attach the ZIP. PRO returns a **Handoff Pack** (add‑only), with:
+   - Updated `q/*.yaml` (assumptions, failure_modes, acceptance, doc_refs, depends_on as needed; titles remain interrogative).
+   - **Idempotent Change Preview** (full text for new files; minimal diffs for edits).
+   - **Issue one‑liners** (labels: `type:*`, `agenda:*`, `priority:*`, `q:<ID>`).
+   - A WARN if PRO needed context **beyond** the ZIP, plus an explicit suggestion of which files/sections to include next time.
+
+4) **AUTO apply**  
+   AUTO opens `apply-pro/<pack_id>` branch, regenerates the derived graph, validates, commits, opens PR.
+
+5) **Merge**  
+   Squash‑merge; auto‑delete head branch. Start the next discovery.
+
+---
+
+## AUTO discovery pass (what AUTO must do)
+
+- **Pin & report** the commit (`commit_sha`).
+- **Inventory**
+  - **Nodes** (`nodes/*.yaml`): `id`, `title`, `owners`, `agenda`, `priority`, `questions[]`.
+  - **Questions** (`q/*.yaml`): `id`, `owner_node`, `status`, `title`, `depends_on[]`, presence of `assumptions`, `failure_modes`, `acceptance`, `doc_refs`.
+  - **Graph**: derive `docs/Q_Chain/QUESTION_GRAPH.yaml` from per‑question `depends_on`; compute **reverse deps** (how many depend on each UNK).
+  - **Doc refs**: which paths exist vs missing.
+- **Analysis**
+  - Rank **gating questions** by  
+    `Score = 3×Dependents + PriorityWeight + AgendaWeight + MissingFieldCount`,  
+    where `PriorityWeight: P0=3,P1=2,P2=1,P3=0`, `AgendaWeight: now=2,next=1,later=0`, `MissingFieldCount: +1 each for empty {assumptions,failure_modes,acceptance,doc_refs}`.
+  - Propose **2–3 candidate packs** (e.g., Governance/Workflow; Foundations; Execution; Partnerships; Metrics) with a one‑line rationale each.
+- **Ask** ≤5 **yes/no or single‑select** clarifying questions to pick **one** pack.
+- **Package** Upload‑Exactly (only the listed files; if a doc specifies `[sections: ...]`, include an **extracted copy** with only those sections).
+- **Return**: ZIP, `MANIFEST.lock`, `pack_id.txt`, and the one‑liner to rebuild the ZIP locally with `git archive`.
+
+---
+
+## Upload‑Exactly packaging (rules)
+
+- ZIPs are **not** committed; keep under `dist/` (gitignored).
+- `MANIFEST.lock` lines: `sha256<TAB>size_bytes<TAB>path`; final line: `commit_sha<TAB><SHA>`.
+- If PRO needs more context, it must **WARN** and propose **exact** additions for the next pack.
+
+---
+
+## Split model (what lives where)
+
+- **Node shells** → `nodes/Q-*.yaml`  
+  Minimal ownership/agenda container. Required fields:
+  - `id`, `title`, `owners[]`, `agenda`, `priority`, `irreversibility`, `questions[]`, `notes[]` (thin provenance).
+- **Questions** → `q/UNK-*.yaml`  
+  Self‑describing unit of work. Required fields:
+  - `id`, `owner_node`, `title` (interrogative), `status` (`open|answered`),  
+    `depends_on[]` (list of UNK IDs),  
+    `assumptions[]`, `failure_modes[]`, `acceptance[]`, `doc_refs[]`,  
+    `notes[]` (provenance lines OK).
+- **Derived graph** → `docs/Q_Chain/QUESTION_GRAPH.yaml`  
+  Built **only** by script from `q/*.yaml`. Never hand‑edit.
+
+**ID conventions**
+- **Questions:** `^UNK-[A-Z0-9]{3,}-\d{2}$` (use a single tag without internal hyphens; e.g., `UNK-MRKTR-01`).  
+- **Nodes:** `^Q-[A-Z0-9-]+$`.
+
+---
+
+## Branch & CI policy
+
+- Base branch: `main` (protected; require CI; squash merges; auto‑delete head).  
+- One concern per branch: `feat/*`, `chore/*`, `docs/*`, `apply-pro/<pack_id>`.  
+- CI validates: node/question structure, unknown IDs, and graph derivation.
+
+---
+
+## Issues & labels (work tracking)
+
+- **Exactly one** scope label per issue: `q:<ID>`.  
+  - Node issue → `type:node` + `q:Q-*`.  
+  - Question issue → `type:question` + `q:UNK-*`.
+- Agenda drives work: `agenda:now|next|later`.  
+- Priority: `priority:P0..P3`.  
+- Optional: `qchain`, `rci-*`, `type:chore`.
+- One question per issue. PRs reference issues (`Closes #nn`).
+
+---
+
+## Artefacts & handoff packs
+
+- **AUTO** keeps handoff metadata under `artefacts/handoff/<pack_id>/` (e.g., `PR_BODY.md`, `CHECKS.md`).  
+- **PRO** returns add‑only file contents in chat (ZIP or code blocks) plus an **Idempotent Change Preview**; AUTO materializes into a branch and PR.  
+- Upload‑Exactly ZIPs live locally or in chat; they are not committed.
+
+---
+
+## Security & hygiene
+
+- Do not include secrets or large binaries in ZIPs; prefer paths in `doc_refs`.  
+- Keep `.gitignore` covering `dist/` and `*.zip`.

--- a/docs/Q_Chain/PROJECT_PROFILE_OVERLAY.md
+++ b/docs/Q_Chain/PROJECT_PROFILE_OVERLAY.md
@@ -1,12 +1,43 @@
-# Project Profile Overlay (context‑agnostic)
+# Project Profile Overlay (content‑agnostic)
+
 language_policy: { internal: EN, external: TR+EN mirror (if relevant) }
+
 lanes:
   gate_first: []
   revenue_lane: []
   supports: []
+
 cadence:
   agenda_refresh: "each working session"
   meeting_notes: "append-only per session"
+
 policy:
   pr_branch: "one concern per branch; Conventional Commits; squash"
-  issues_labels: ["type:","priority:P0..P3","agenda:{now|next|later}","status:","q:<ID>"]
+  issues_labels: ["type:","priority:P0..P3","agenda:{now|next|later}","q:<ID>"]
+
+branch_policy:
+  default_base: main
+  merge: squash
+  auto_delete_head: true
+  one_concern_per_branch: true
+
+labels_required:
+  - type:node
+  - type:question
+  - agenda:now
+  - agenda:next
+  - agenda:later
+  - priority:P0
+  - priority:P1
+  - priority:P2
+  - priority:P3
+
+artefact_rules:
+  packages: "Upload‑Exactly zips are not committed; keep under dist/ (gitignored)"
+  graph: "docs/Q_Chain/QUESTION_GRAPH.yaml is derived by script from q/*.yaml; never edit by hand"
+
+packaging:
+  upload_exactly_zip: true
+  manifest_lock: true
+  pack_id_txt: true
+  pin_to_commit: true

--- a/scripts/setup_labels_qchain.sh
+++ b/scripts/setup_labels_qchain.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure we're inside a Git repo
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Run this from your repository root."; exit 1
+fi
+
+# Require GitHub CLI and auth
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI 'gh' not found. Install via 'brew install gh'."; exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "GitHub CLI is not authenticated. Run 'gh auth login'."; exit 1
+fi
+
+# Helper: create a label if missing (idempotent)
+mk() {
+  local name="$1"; local color="${2:-#ededed}"; local desc="${3:-}"
+  if [[ -n "${DRY_RUN:-}" ]]; then
+    echo "DRY_RUN: gh label create \"$name\" -c \"$color\" ${desc:+-d \"$desc\"}"
+    return
+  fi
+  gh label create "$name" -c "$color" ${desc:+-d "$desc"} >/dev/null 2>&1 || true
+}
+
+# Base taxonomy
+mk "type:node"     "#0366d6" "Node shell"
+mk "type:question" "#8a63d2" "Question (UNK-*)"
+mk "type:pack"     "#0b7285" "Handoff pack"
+mk "type:chore"    "#6a737d" "Chore / infra"
+
+mk "priority:P0" "#b60205" "Critical"
+mk "priority:P1" "#d93f0b" "High"
+mk "priority:P2" "#fbca04" "Medium"
+mk "priority:P3" "#0e8a16" "Low"
+
+mk "agenda:now"   "#0052cc" "Work now"
+mk "agenda:next"  "#2188ff" "Up next"
+mk "agenda:later" "#c5def5" "Later"
+
+# Project tags
+mk "qchain" "#6f42c1" "Question Chain"
+mk "rci-v2" "#e99695" "Handoff RCI v2"
+
+# Dynamic scope labels: q:<ID> for all Node/Question IDs
+ids=$(
+  { grep -rhoE '^id:\s*(Q-[A-Z0-9-]+)' nodes 2>/dev/null;
+    grep -rhoE '^id:\s*(UNK-[A-Z0-9-]+)' q 2>/dev/null; } \
+  | awk '{print $2}' | sort -u
+)
+for id in $ids; do
+  mk "q:$id" "#ededed" "Scope label for $id"
+done
+
+echo "Labels bootstrapped."


### PR DESCRIPTION
Adds content‑agnostic instructions: AUTO‑led discovery pass, Upload‑Exactly ZIPs pinned to commit with MANIFEST.lock, split model rules, branch/CI & labels policy.