### PR TITLE
chore(gitignore): ignore backup/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 rci-2025-09-08-v2_add-only_bundle.zip
+backup/


### PR DESCRIPTION
Ignore local safety copies placed under backup/; avoids noisy working tree during PRs.